### PR TITLE
Fix for js-controller 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The Adapter should now restart, and you are ready to go!
 
 
 ## Changelog
+### 0.1.7 (2023-05-16)
+* (todde99) Fixed js-controller 5 issue
+
 ### 0.1.5 (2018-09-18)
 * (BuZZy1337) Check response of Doorbird when triggering relays
 * (BuZZy1337) Check if any favorite has to be updated (For example when adapter address or port changes)

--- a/io-package.json
+++ b/io-package.json
@@ -3,6 +3,10 @@
         "name": "doorbird",
         "version": "0.1.5",
         "news": {
+            "0.1.7": {
+                "en": "Fixed js-controller 5 issue"
+                "de": "Problem mit js-controller 5 behoben"
+            },
             "0.1.5": {
                 "en": "Just some changes under the hood",
                 "de": "Nur ein paar Änderungen unter der Haube",

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@
 
 
 var utils = require(__dirname + '/lib/utils');
+var ioButils = require('@iobroker/adapter-core');
 var birdConCheck;
 var adapter = new utils.Adapter('doorbird');
 var dgram = require('dgram');
@@ -22,7 +23,10 @@ var scheduleState = {};
 var motionState = {};
 var doorbellsArray = []; // Contains all Doorbell IDs
 var favoriteState = {}; // {'ID of Doorbell/Motion': 'ID of Favorite'}
-var jpgpath = path.normalize(path.join(utils.controllerDir, require(path.join(utils.controllerDir, 'lib', 'tools.js')).getDefaultDataDir()) + '/' + adapter.namespace + '.snap.jpg');
+//This is not working with js-controller 5.0 anymore. Chaning to 'getAbsoluteInstanceDataDir'
+//var jpgpath = path.normalize(path.join(utils.controllerDir, require(path.join(utils.controllerDir, 'lib', 'tools.js')).getDefaultDataDir()) + '/' + adapter.namespace + '.snap.jpg');
+var instanceDir = ioButils.getAbsoluteInstanceDataDir(adapter);
+var jpgpath = path.join(ioButils.getAbsoluteInstanceDataDir(adapter), 'snap.jpg');
 var download = function (url, filename, callback) {
     request.head(url, function (err, res, body) {
         request(url).pipe(fs.createWriteStream(filename)).on('close', callback);
@@ -513,6 +517,11 @@ function sendToState(cmd) {
 
 
 function main() {
+    //create adapter dir if not availible
+    if (!fs.existsSync(instanceDir)) {
+        fs.mkdirSync(instanceDir);
+    }
+    
     if (adapter.config.birdip && adapter.config.birdpw && adapter.config.birduser) {
         testBird();
         birdConCheck = setInterval(testBird, 180000);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.doorbird",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "ioBroker doorbird Adapter",
   "author": {
     "name": "BuZZy1337",


### PR DESCRIPTION
Issue #27 fixed: https://github.com/BuZZy1337/ioBroker.doorbird/blob/master/main.js#L25 leads with js-controller 5.x in an uncaught exception. Fixed with getAbsoluteInstanceDataDir.